### PR TITLE
feat: ignore transactions which were not added to history

### DIFF
--- a/src/inputrules.js
+++ b/src/inputrules.js
@@ -56,7 +56,7 @@ export function inputRules({rules}) {
       apply(tr, prev) {
         let stored = tr.getMeta(this)
         if (stored) return stored
-        return tr.selectionSet || tr.docChanged ? null : prev
+        return (tr.selectionSet || tr.docChanged) && tr.getMeta('addToHistory') !== false ? null : prev
       }
     },
 


### PR DESCRIPTION
`prosemirror-history` reads a metadata field `addToHistory` and doesn't
allow to undo changes if a transactions sets it to `false`. I think its
reasonable that this plugin ignores these transactions as well as they
are not undoable by the undo command anyways.