### PR TITLE
Fix handler positions for regexes without final $

### DIFF
--- a/src/inputrules.js
+++ b/src/inputrules.js
@@ -87,8 +87,11 @@ function run(view, from, to, text, rules, plugin) {
                                             null, "\ufffc") + text
   for (let i = 0; i < rules.length; i++) {
     let match = rules[i].match.exec(textBefore)
-    let tr = match && rules[i].handler(state, match, from - (match[0].length - text.length), to)
-    if (!tr) continue
+    if (!match) continue;
+    let handleFrom =
+      from + text.length - match.input.length + match.index;
+    let handleTo = to < handleFrom + match[0].length ? to : handleFrom + match[0].length;
+    let tr = rules[i].handler(state, match, handleFrom, handleTo)
     view.dispatch(tr.setMeta(plugin, {transform: tr, from, to, text}))
     return true
   }


### PR DESCRIPTION
Hi Marijn!

(NB I am opening this PR as an independent developer and not associated with any organization.)

In the current implementation, the following type of input rule produces an unexpected result. The `start` and `end` arguments passed to the handler are calculated based on the assumption that the matched input has fallen immediately before the most recent user input, so the `end` position is always the same as the forward-most position of the selection at the moment when the user typed the input that triggered the match.

I see that the documentation recommends that developers end their regexes with `$` to accommodate this behavior. But I would like my users to be able to type, for example, the final backtick before they go back and add the opening backtick, and for the input rule still to work.

The documentation also says “The rule applies when the user typed something and the text directly in front of the cursor matches `match`,” which is not, strictly speaking, how the matches are executed; because the input rule scans the document backwards on any user input, if a user types later in the paragraph where the rule has matched, it will call the handler.

```
new InputRule(new RegExp('`(.*?)`', (state, match, start, end) => {
  // replace between start and end with text + marks
  // 'start' and 'end' values will be wrong if user types later in node
});
```

This leads to some strange behavior if you omit the `$` from your pattern, because if you insert the backticks in the wrong order, for example, and then try to type somewhere *after* them in the same node, you suddenly get a block of code inserted behind your current cursor, the contents of which are the matched code inside the preceding backticks.

```
# user adds backticks in the wrong order
<p>lorem ipsum `dolor` sit amet</p>

# user tries to type           |
#                              ▼
<p>lorem ipsum `dolor` sit amet</p>

# result
<p>lorem ipsum `dolor` sit<code>dolor</code></p>
```

This PR changes the way the `start` and `end` positions are calculated so they will be correct no matter where the user’s input takes place. It continues to be correct in the standard case and it also corrects the positions in the non-standard case.

The behavior still isn't ideal, because (among other reasons) the input rule will not match until the user types after the matching pattern. So in my example above, the text will not get wrapped with the code mark until the user types somewhere after the wrapped piece of text. But this is better than how the input rules execute now, since if the user either intentionally or unintentionally inserts some matching input, their subsequent input is liable to be disrupted unexpectedly.