### PR TITLE
Handle inputRules on Enter

### DIFF
--- a/src/inputrules.js
+++ b/src/inputrules.js
@@ -71,6 +71,12 @@ export function inputRules({rules}) {
             if ($cursor) run(view, $cursor.pos, $cursor.pos, "", rules, plugin)
           })
         }
+      },
+      handleKeyDown(view, event) {
+        if (event.key !== "Enter") return false;
+        let {$cursor} = view.state.selection
+        if ($cursor) return run(view, $cursor.pos, $cursor.pos, "\n", rules, plugin)
+        return false;
       }
     },
 


### PR DESCRIPTION
I'm creating an inputRule for links `const inputRegexExact = /(https?:\/\/[\w\d./?=#]+)[\s\n]$/;` that will create my link at the end of a line when the user hit enter. I didn't reach it but it will be perfect that the Enter trigger the inputRules and go to the line but only for marks

https://user-images.githubusercontent.com/20707343/128224623-c794fe97-8cc5-404e-a677-c096e30dcff9.mov

It work for Heading and block to

https://user-images.githubusercontent.com/20707343/128225481-37324416-6cb3-4636-902a-81d9fc1c4558.mov

