### PR TITLE
Pass EditorState to getAttrs callback of rule builders

### DIFF
--- a/src/rulebuilders.js
+++ b/src/rulebuilders.js
@@ -1,7 +1,7 @@
 import {InputRule} from "./inputrules"
 import {findWrapping, canJoin} from "prosemirror-transform"
 
-// :: (RegExp, NodeType, ?union<Object, ([string]) → ?Object>, ?([string], Node) → bool) → InputRule
+// :: (RegExp, NodeType, ?union<Object, (match: [string], state: EditorState) → ?Object>, ?([string], Node) → bool) → InputRule
 // Build an input rule for automatically wrapping a textblock when a
 // given string is typed. The `regexp` argument is
 // directly passed through to the `InputRule` constructor. You'll
@@ -19,7 +19,7 @@ import {findWrapping, canJoin} from "prosemirror-transform"
 // return a boolean to indicate whether a join should happen.
 export function wrappingInputRule(regexp, nodeType, getAttrs, joinPredicate) {
   return new InputRule(regexp, (state, match, start, end) => {
-    let attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs
+    let attrs = getAttrs instanceof Function ? getAttrs(match, state) : getAttrs
     let tr = state.tr.delete(start, end)
     let $start = tr.doc.resolve(start), range = $start.blockRange(), wrapping = range && findWrapping(range, nodeType, attrs)
     if (!wrapping) return null
@@ -32,7 +32,7 @@ export function wrappingInputRule(regexp, nodeType, getAttrs, joinPredicate) {
   })
 }
 
-// :: (RegExp, NodeType, ?union<Object, ([string]) → ?Object>) → InputRule
+// :: (RegExp, NodeType, ?union<Object, (match: [string], state: EditorState) → ?Object>) → InputRule
 // Build an input rule that changes the type of a textblock when the
 // matched text is typed into it. You'll usually want to start your
 // regexp with `^` to that it is only matched at the start of a
@@ -42,7 +42,7 @@ export function wrappingInputRule(regexp, nodeType, getAttrs, joinPredicate) {
 export function textblockTypeInputRule(regexp, nodeType, getAttrs) {
   return new InputRule(regexp, (state, match, start, end) => {
     let $start = state.doc.resolve(start)
-    let attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs
+    let attrs = getAttrs instanceof Function ? getAttrs(match, state) : getAttrs
     if (!$start.node(-1).canReplaceWith($start.index(-1), $start.indexAfter(-1), nodeType)) return null
     return state.tr
       .delete(start, end)


### PR DESCRIPTION
Hi,

I would like to have an input rule for headings that automatically uses the attributes of the first heading in the document (for example font-size and color). I figured the easiest solution would be to search for the first heading node in the `getAttrs` callback and return the attributes of that node. This PR will add a second state parameter to the `getAttrs` callback.